### PR TITLE
Add process details to contributor's guide

### DIFF
--- a/src/contributors_guide.md
+++ b/src/contributors_guide.md
@@ -1,6 +1,26 @@
 # Contributor's Guide
 
-Please contact @glyph on Scuttlebutt or via email if you're excited about PeachCloud and wish to discuss potential contributions.
+Anyone who feels excited about PeachCloud is encouraged to contact @glyph on Scuttlebutt or via email to discuss potential contributions. Please include details on what attracts you to PeachCloud, how you might like to contribute and what relevant experience you have. It's worth noting that you don't have to be a programmer to offer meaningful contributions.
 
 SSB: `@HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519`  
 Email: <glyph@mycelial.technology>
+
+## Processes
+
+### Coordination
+
+Project management and coordination take place on [Asana](https://asana.com/). This service allows the creation and assignment of tasks - as well as the ability to track task completion and share task-related notes among team members. Upon invitation to contribute to PeachCloud, new contributors will be sent an email invitation to join the MVP Development project on Asana.
+
+[Signal messenger](https://www.signal.org/) is used for day-to-day communications, process-related queries and interpersonal check-ins. [Jitsi Meet](https://meet.jit.si/) video calls are held once every two weeks and prior to the onboarding of new developers. [Mumble](https://www.mumble.info/) is used for audio calls when one or several contributors are on slow or degraded internet connections.
+
+### Code
+
+PeachCloud repositories are based on GitHub and are collected under the [PeachCloud organization](https://github.com/peachcloud). New contributors will be added to the 'contributors' team and given appropriate access permissions.
+
+GitHub issues are used to discuss repository-specific bugs and features.
+
+Contributions to repositories are made in the form of pull-requests from forked repositories. Pull-requests bundle multiple commits and offer an opportunity to request comment or code review from fellow contributors. Contributors are encouraged to submit concise yet detailed descriptions when submitting pull-requests, and may even add screenshots or other images when desired. Over time, the pull-request history helps to tell the story of component development at a greater level of granularity than single commits.
+
+### Developer Diaries
+
+Contributors to PeachCloud may wish to create a 'dev diary' thread on Scuttlebutt, though this is entirely optional and up to each individual. Dev diaries are a fun way to share and celebrate project progress with fellow Butts. A personal diary / log may also be kept to track work tasks and rhythms, and to offer a document for reflection.


### PR DESCRIPTION
I've added process-related details to the contributor's guide for coordination, code and developer diaries. This is intended to give prospective and new contributors a clear insight into the workflow for PeachCloud.

@mhfowler Would you mind reading through this when you have a chance and offering any suggestions?