### PR TITLE
Fix syntax highlighting and remove CI code tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - cargo install-update -a
 
 script:
-  - mdbook build && mdbook test
+  - mdbook build

--- a/src/quick_deployment.md
+++ b/src/quick_deployment.md
@@ -10,8 +10,10 @@ Download the latest Debian Buster preview image for RPi3 and flash it to an SD c
 
 Note: Be sure to use the correct device location in the `dd` command, otherwise you risk wiping another connected USB device. `sudo dmesg | tail` can be run after plugging in the SD card to determine the correct device location:
 
-`wget https://raspi.debian.net/verified/20200831_raspi_3.img.xz`
-`xzcat 20190628_raspberry-pi-3_buster_PREVIEW.img.xz | sudo dd of=/dev/mmcblk0 bs=64k oflag=dsync status=progress`
+```bash
+wget https://raspi.debian.net/verified/20200831_raspi_3.img.xz
+xzcat 20190628_raspberry-pi-3_buster_PREVIEW.img.xz | sudo dd of=/dev/mmcblk0 bs=64k oflag=dsync status=progress
+```
 
 On Mac OS, use the following command to flash the SD card:
 
@@ -40,7 +42,7 @@ nano /etc/wpa_supplicant/wpa_supplicant.conf
 
 [ Add the following two lines to top of file ]
 
-```bash
+```plaintext
 ctrl_interface=/run/wpa_supplicant
 update_config=1
 ```
@@ -54,7 +56,7 @@ nano /etc/network/interfaces
 
 [ Add the following lines to the file ]
 
-```bash
+```plaintext
 auto lo
 iface lo inet loopback
 

--- a/src/software/microservices/peach-monitor.md
+++ b/src/software/microservices/peach-monitor.md
@@ -18,7 +18,7 @@ The `--iface` argument is used to define the network interface from which to ret
 
 `peach-monitor [FLAGS] [OPTIONS]`
 
-```
+```bash
 FLAGS:
     -d, --daemon     Run daemon
     -h, --help       Prints help information
@@ -35,7 +35,7 @@ OPTIONS:
 
 `~/.local/share/peachcloud`
 
-```
+```bash
 .
 └── net
     ├── alert.json          // programatically-defined alert flags

--- a/src/software/operating_system/nginx.md
+++ b/src/software/operating_system/nginx.md
@@ -4,7 +4,7 @@
 
 The configuration file for `nginx` can be found at `/etc/nginx/sites-available/peach.conf`. The contents are as follows:
 
-```
+```nginx
 server {
         listen 80;
         server_name peach www.peach;


### PR DESCRIPTION
I realized that running `mdbook test` with Travis CI is unnecessary since we don't actually have any Rust code to test in the docs. More often than not, the tests cause a failed build because unlabelled code blocks are automatically interpreted as Rust code. We can add `mdbook test` to the build pipeline at a later stage if the situation changes.

This PR also makes minor improvements to syntax highlighting by labeling existing code blocks (as bash, plaintext or nginx).