### PR TITLE
Update instructions for cross-compiling and building deb packages

### DIFF
--- a/src/software/compilation.md
+++ b/src/software/compilation.md
@@ -24,12 +24,16 @@ These instructions cover cross-compilation for Debian Buster running on a Raspbe
 
 `export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc`
 
-Alternatively, create a file named `cargo-config` in the root directory of the crate and add the following:
+Alternatively, create a file named `config` in the `~/.cargo` directory of the home user and add the following:
 
 ```bash
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+objcopy = { path ="aarch64-linux-gnu-objcopy" }
+strip = { path ="aarch64-linux-gnu-strip" }
 ```
+
+The `objcopy` and `strip` parameters are needed by `cargo deb` when cross-compiling Debian packages.
 
 **Compile release build:**
 

--- a/src/software/packaging.md
+++ b/src/software/packaging.md
@@ -4,16 +4,26 @@ The microservices comprising the PeachCloud software suite are packaged for easy
 
 Each microservice repository includes a `debian` directory which includes a `systemd` service file and Debian maintainer scripts, including `postinst`, `postrm` and `prerm` scripts. These scripts define behavior for installing and uninstalling the respective services. `deb` packages are created using the `cargo-deb` tool ([crate](https://crates.io/crates/cargo-deb)).
 
-Microservices can be installed with `dpkg` as follows:
+**Install cargo-deb:**
+
+`cargo install cargo-deb`
+
+**Create the package:**
+
+`cargo deb --target aarch64-unknown-linux-gnu`
+
+Note: the correct linker, objcopy and strip parameters must be defined in `~/.cargo/config` for the above command to execute successfully. Visit the [Compilation](/software/compilation.md) page and look under 'Configure the linker' for more details.
+
+**Install the package:**
 
 `sudo dpkg -i peach-network_0.1.0_arm64.deb`
 
 The service will be automatically enabled and started.
 
-Uninstall the service:
+**Uninstall the package:**
 
 `sudo apt-get remove peach-network`
 
-Remove configuration files (not removed with `apt-get remove`):
+**Remove configuration files** (not removed with `apt-get remove`):
 
 `sudo apt-get purge peach-network`


### PR DESCRIPTION
Adds details on creating the cargo configuration file (`~/.cargo/config`) for aarch64 cross-compilation, as well as building `.deb` packages for aarch64 target.