### PR TITLE
Fix wpa supplicant control interface definition

### DIFF
--- a/src/quick_deployment.md
+++ b/src/quick_deployment.md
@@ -43,7 +43,7 @@ nano /etc/wpa_supplicant/wpa_supplicant.conf
 [ Add the following two lines to top of file ]
 
 ```plaintext
-ctrl_interface=/run/wpa_supplicant
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=wpactrl-user
 update_config=1
 ```
 


### PR DESCRIPTION
Uses the correct path for the control interface and adds the `wpactrl-user` group which allows the `peach-network` microservice to run with the correct permissions.