### PR TITLE
Add eth0 to quick_deployment devdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 book
 src/tmp
 notes
+deploy.sh
+.idea

--- a/src/quick_deployment.md
+++ b/src/quick_deployment.md
@@ -64,6 +64,10 @@ allow-hotplug wlan0
 auto wlan0
 iface wlan0 inet dhcp
     wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
+    
+allow-hotplug eth0
+auto eth0
+iface eth0 inet dhcp
 ```
 
 [ Save and exit ]


### PR DESCRIPTION
This may help other future developers set up a dev workflow for working with ethernet.

Originally I wasn't sure if there was more I would have to do to set this up. 

If you want to add this here, I can also add this to peach-config so its mirrored there. 