### PR TITLE
Bump version number of devdocs to 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-devdocs
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-devdocs.svg?branch=master)](https://travis-ci.com/peachcloud/peach-devdocs) ![Generic badge](https://img.shields.io/badge/version-0.3.0-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-devdocs.svg?branch=master)](https://travis-ci.com/peachcloud/peach-devdocs) ![Generic badge](https://img.shields.io/badge/version-0.3.1-<COLOR>.svg)
 
 Developer documentation for [PeachCloud](https://github.com/peachcloud) in the form of a Markdown book.
 


### PR DESCRIPTION
Forgot to do this in last PR, so doing this here 